### PR TITLE
解决事务日志使用文件方式存储时只能保存第一次事务日志的问题，及关闭RandomAccessFile

### DIFF
--- a/myth-common/src/main/java/com/github/myth/common/utils/FileUtils.java
+++ b/myth-common/src/main/java/com/github/myth/common/utils/FileUtils.java
@@ -53,15 +53,15 @@ public class FileUtils {
             throw new MythRuntimeException(e);
         } 
         finally { // add by eddy
-        	if(null != raf)
-        	{
-        		try {
-					raf.close();
-				} catch (IOException e) {
-					e.printStackTrace();
-		            throw new MythRuntimeException(e);
-				}
-        	}
+	    if(null != raf)
+	    {
+		try {
+		    raf.close();
+		} catch (IOException e) {
+		    e.printStackTrace();
+		    throw new MythRuntimeException(e);
+		}
+	    }
         }
     }
 }

--- a/myth-common/src/main/java/com/github/myth/common/utils/FileUtils.java
+++ b/myth-common/src/main/java/com/github/myth/common/utils/FileUtils.java
@@ -36,8 +36,9 @@ public class FileUtils {
      * @param contents 内容
      */
     public static void writeFile(final String fullFileName, final byte[] contents) {
+        RandomAccessFile raf = null;
         try {
-            RandomAccessFile raf = new RandomAccessFile(fullFileName, "rw");
+            raf = new RandomAccessFile(fullFileName, "rw");
             try (FileChannel channel = raf.getChannel()) {
                 ByteBuffer buffer = ByteBuffer.allocate(contents.length);
                 buffer.put(contents);
@@ -50,6 +51,17 @@ public class FileUtils {
         } catch (IOException e) {
             e.printStackTrace();
             throw new MythRuntimeException(e);
+        } 
+        finally { // add by eddy
+        	if(null != raf)
+        	{
+        		try {
+					raf.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+		            throw new MythRuntimeException(e);
+				}
+        	}
         }
     }
 }

--- a/myth-core/src/main/java/com/github/myth/core/spi/repository/FileCoordinatorRepository.java
+++ b/myth-core/src/main/java/com/github/myth/core/spi/repository/FileCoordinatorRepository.java
@@ -227,6 +227,6 @@ public class FileCoordinatorRepository implements CoordinatorRepository {
                 }
             }
         }
-        return false;
+        return true;// 已初始化目录，直接返回true
     }
 }


### PR DESCRIPTION
解决事务日志使用文件方式存储时只能保存第一次事务日志的问题，及关闭RandomAccessFile